### PR TITLE
[CLOUD-296] Adding  state=present rather than a state=started

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -20,5 +20,5 @@
   when: elasticsearch_state == 'present'
 
 - name: Ensure Elasticsearch is running
-  supervisorctl: name=elasticsearch state=started
+  supervisorctl: name=elasticsearch state=present
   when: elasticsearch_supervisor_state == 'started' and elasticsearch_state == 'present'


### PR DESCRIPTION
@DanielRedOak What do you think of this change?  Seems to pass tests.  