### PR TITLE
Add /etc/elasticsearch directory for plugin installs

### DIFF
--- a/roles/elasticsearch/tasks/generic_plugins.yml
+++ b/roles/elasticsearch/tasks/generic_plugins.yml
@@ -6,5 +6,6 @@
   with_items: elasticsearch_plugins
   when: elasticsearch_plugins is defined
   ignore_errors: yes
-
+  args:
+    chdir: /etc/elasticsearch
 


### PR DESCRIPTION
if this is run from a directory with an `elasticsearch.yml` ( for example, in an ansible playbook ) , it will try to take that as the elasticsearch config, so changing explicitly to /etc/elasticsearch _should_ avoid all the permutations of that issue.