### PR TITLE
Setting directory for plugin installs

### DIFF
--- a/roles/elasticsearch/tasks/generic_plugins.yml
+++ b/roles/elasticsearch/tasks/generic_plugins.yml
@@ -3,6 +3,8 @@
   shell: sudo -E -u {{ elasticsearch_user }} {{ elasticsearch_install_path }}/elasticsearch/bin/plugin --install {{ item.name }}
   environment:
     JAVA_HOME: "{{ elasticsearch_java_home }}"
+  args:
+    chdir: "{{ elasticsearch_install_path }}"
   with_items: elasticsearch_plugins
   when: elasticsearch_plugins is defined
   ignore_errors: yes


### PR DESCRIPTION
plugin installs appear to interact with ./elasticsearch.yml if it exists;
explicitly setting the cwd of the plugin invocation should avoid this ever
being a problem.  It was happening for me when running from /tmp/ansible in
the cloud from a playbook (fulfillment-solicitor) that has an elasticsearch.yml
itself.