### PR TITLE
fix to hide script.disable_dynamic var in config in order to work with custom options

### DIFF
--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -124,7 +124,7 @@ discovery.zen.ping.multicast.enabled: {{ elasticsearch_discovery_zen_ping_multic
 discovery.zen.ping.unicast.hosts: {{ elasticsearch_discovery_zen_ping_unicast_hosts }}
 {% endif %}
 http.jsonp.enable: false
-{% if elasticsearch_script_disable_dynamic is defined and elasticsearch_script_disable_dynamic %}
+{% if elasticsearch_script_disable_dynamic is defined and (elasticsearch_script_disable_dynamic == "true" or elasticsearch_script_disable_dynamic == "false") %}
 script.disable_dynamic: {{ elasticsearch_script_disable_dynamic }}
 {% endif %}
 {% if elasticsearch_http_cors_enabled is defined %}

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -124,7 +124,7 @@ discovery.zen.ping.multicast.enabled: {{ elasticsearch_discovery_zen_ping_multic
 discovery.zen.ping.unicast.hosts: {{ elasticsearch_discovery_zen_ping_unicast_hosts }}
 {% endif %}
 http.jsonp.enable: false
-{% if elasticsearch_script_disable_dynamic is defined %}
+{% if elasticsearch_script_disable_dynamic is defined and elasticsearch_script_disable_dynamic %}
 script.disable_dynamic: {{ elasticsearch_script_disable_dynamic }}
 {% endif %}
 {% if elasticsearch_http_cors_enabled is defined %}


### PR DESCRIPTION
fix to hide script.disable_dynamic var in config in order to work with options like script.inline: sandbox, script.indexed: sandbox, script.file: on, script.engine.groovy.inline.update: on, script.disable_dynamic: false